### PR TITLE
ci: add autoblacks actions

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -1,0 +1,35 @@
+name: Check / auto apply Black
+on:
+  push:
+      branches:
+          - main
+jobs:
+  black:
+    name: Check / auto apply black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check files using the black formatter
+        uses: psf/black@stable
+        id: black
+        with:
+          options: "."
+        continue-on-error: true
+      - shell: pwsh
+        id: check_files_changed
+        run: |
+          # Diff HEAD with the previous commit
+          $diff = git diff
+          $HasDiff = $diff.Length -gt 0
+          Write-Host "::set-output name=files_changed::$HasDiff"
+      - name: Create Pull Request
+        if: steps.check_files_changed.outputs.files_changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Format Python code with Black"
+          commit-message: ":art: Format Python code with Black"
+          body: |
+            This pull request uses the [psf/black](https://github.com/psf/black) formatter.
+          base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
+          branch: actions/black


### PR DESCRIPTION
This add the autoblack action from moulinette on this repository (while adapting the branch name).

This action automatically generate a pull request to format the code with black so we don't lose time by having to run it manually when needed.