### PR TITLE
feat: add link to stripe portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ BABEL_TRANSLATION_DIRECTORIES = 'locales'
 # Customization
 CUSTOM = {}
 CUSTOM['name'] = 'YunoHost'
+# You can activate a donation management portal on https://dashboard.stripe.com/settings/billing/portal and display a link to it on the homepage.
+CUSTOM['portal_url'] = ''
 CUSTOM['contact_url'] = 'mailto:donate-6521@yunohost.org'
 CUSTOM['logo'] = 'https://yunohost.org/user/images/logo.png'
 CUSTOM['favicon'] = 'https://yunohost.org/user/themes/yunohost-docs/images/favicon.png'

--- a/assets/index.html
+++ b/assets/index.html
@@ -45,7 +45,17 @@
         {{ _('Donate') }}
       </button>
 
-      <p><a href="{{ contact_url }}">{{ _('If you want to cancel a monthly donation, please contact us') }}</a></p>
+      <div class="mt-3">
+        {% if portal_url %}
+        <p class="mb-2">
+          <a href="{{ portal_url }}">{{ _('Manage your monthly donation') }}</a>
+        </p>
+        {% endif %}
+  
+        <p>
+          <a href="{{ contact_url }}">{{ _('Contact us') }}</a>
+        </p>
+      </div>
 
       <div id="error-message"></div>
     </div>

--- a/locales/en/LC_MESSAGES/messages.po
+++ b/locales/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-22 04:43+0200\n"
+"POT-Creation-Date: 2025-03-31 17:03+0200\n"
 "PO-Revision-Date: 2021-02-18 23:33+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.15.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: assets/canceled.html:8 assets/index.html:8 assets/success.html:8
 #, python-format
@@ -65,8 +65,12 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: assets/index.html:48
-msgid "If you want to cancel a monthly donation, please contact us"
+#: assets/index.html:51
+msgid "Manage your monthly donation"
+msgstr ""
+
+#: assets/index.html:56
+msgid "Contact us"
 msgstr ""
 
 #: assets/success.html:22

--- a/locales/fr/LC_MESSAGES/messages.po
+++ b/locales/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-22 04:43+0200\n"
+"POT-Creation-Date: 2025-03-31 17:03+0200\n"
 "PO-Revision-Date: 2021-02-18 23:33+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.15.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: assets/canceled.html:8 assets/index.html:8 assets/success.html:8
 #, python-format
@@ -66,11 +66,13 @@ msgstr "une fois"
 msgid "Donate"
 msgstr "Donner"
 
-#: assets/index.html:48
-msgid "If you want to cancel a monthly donation, please contact us"
-msgstr ""
-"Si vous souhaitez mettre fin à votre don mensuel, contactez-nous s'il "
-"vous plaît"
+#: assets/index.html:51
+msgid "Manage your monthly donation"
+msgstr "Gérer votre don mensuel"
+
+#: assets/index.html:56
+msgid "Contact us"
+msgstr "Contactez-nous"
 
 #: assets/success.html:22
 msgid "Thanks for your donation 🙂"


### PR DESCRIPTION
Add a link to stripe's subscription management portal on the homepage if `CUSTOM["portal_url"]` is set.

Stripe portal can be activated and configured on https://dashboard.stripe.com/settings/billing/portal